### PR TITLE
feat: add unique identifier for cron jobs and update related methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,19 @@
 
 Simple tool that allows users to manage cron jobs for Linux.
 
-
 ## Installing
-One should just type in the terminal: 
+Just type in the terminal:
 ```
 pip install ppycron
 ```
 
 ## Usage
-PPyCron will let you manage crontabs in Unix based environments. When instantiated
-the package will automatically create a cron file if it is not available. 
+PPyCron lets you manage crontab entries in Unix-based environments. When instantiated, the package automatically creates a cron file if one isn’t available. Each cron job is associated with a unique identifier (UUID) so that you can reliably retrieve, edit, or delete specific jobs.
 
 ### Basic Example
-#### Fetching crons registered
-```
+
+#### Fetching Registered Crons
+```python
 In [1]: import ppycron
 
 In [2]: crontab = ppycron.Crontab()
@@ -23,36 +22,39 @@ In [2]: crontab = ppycron.Crontab()
 In [3]: crontab.get_all()
 Out[3]: []
 ```
-#### Adding new Cron
-```
-In [4]: crontab.add(interval="* * * * *", command="echo hello-world >> /var/log/crontab.log")
-Out[4]: Cron(command='echo hello-world >> /var/log/crontab.log', interval='* * * * *')
+
+#### Adding a New Cron
+When you add a new job, a unique ID is automatically generated:
+```python
+In [4]: job = crontab.add(interval="* * * * *", command="echo hello-world >> /var/log/crontab.log")
+Out[4]: Cron(command='echo hello-world >> /var/log/crontab.log', interval='* * * * *', id='3f9c8bd2-1b67-4b78-8c4c-1e49b3f1a0c5')
 
 In [5]: crontab.get_all()
-Out[5]: [Cron(command='echo hello-world >> /var/log/crontab.log', interval='* * * * *')]
+Out[5]: [Cron(command='echo hello-world >> /var/log/crontab.log', interval='* * * * *', id='3f9c8bd2-1b67-4b78-8c4c-1e49b3f1a0c5')]
 ```
 
-#### Editing some existing cron
-We fetch the cron by its command:
-
-```
-In [6]: crontab.edit(interval="*/10 * * * *", cron_command="echo hello-world >> /var/log/crontab.log")
+#### Editing an Existing Cron
+Instead of searching by command, you now edit a job by its unique ID:
+```python
+In [6]: crontab.edit(cron_id=job.id, interval="*/10 * * * *", command="echo hello-world >> /var/log/crontab.log")
 Out[6]: True
 
 In [7]: crontab.get_all()
-Out[7]: [Cron(command='echo hello-world >> /var/log/crontab.log', interval='*/10 * * * *')]
+Out[7]: [Cron(command='echo hello-world >> /var/log/crontab.log', interval='*/10 * * * *', id='3f9c8bd2-1b67-4b78-8c4c-1e49b3f1a0c5')]
 ```
 
-If you check your crontab file you will see
-```
+Now, if you check your crontab file:
+```python
+In [8]: import os
 In [9]: os.system("crontab -l")
 # Created automatically by Pycron =)
 */10 * * * * echo hello-world >> /var/log/crontab.log
 ```
 
-#### Deleting existing crons
-```
-In [10]: crontab.delete("echo hello-world >> /var/log/crontab.log")
+#### Deleting an Existing Cron
+Delete jobs using the job’s unique ID:
+```python
+In [10]: crontab.delete(cron_id=job.id)
 Out[10]: True
 
 In [11]: crontab.get_all()

--- a/ppycron/src/base.py
+++ b/ppycron/src/base.py
@@ -1,5 +1,6 @@
 import abc
 import dataclasses
+import uuid
 from typing import List, Optional
 
 
@@ -7,9 +8,10 @@ from typing import List, Optional
 class Cron:
     command: str
     interval: str
+    id: str = dataclasses.field(default_factory=lambda: str(uuid.uuid4()))
 
     def __str__(self):
-        return f"{self.interval} {self.command}"
+        return f"{self.interval} {self.command} # id: {self.id}"
 
 
 class BaseInterface(metaclass=abc.ABCMeta):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='ppycron',
-    version='0.0.6',
+    version='0.0.7',
     packages=find_packages(),
     url='https://github.com/marciobbj/ppycron',
     install_requires=[

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -5,7 +5,7 @@ from ppycron.src.base import Cron
 
 @pytest.fixture(scope="function")
 def config_file(tmp_path):
-    # Using a temporary file to simulate the crontab content
+    # Usando um arquivo temporário para simular o conteúdo do crontab
     cronfile = tmp_path / "crontab_file"
     cronfile.write_text("# Sample cron jobs for testing\n")
     return cronfile
@@ -18,9 +18,9 @@ def subprocess_run(mocker):
 
 @pytest.fixture
 def subprocess_check_output(mocker, config_file):
-    # Use the content of the temp file as mock data for check_output
+    # Inicialmente, usa o conteúdo do arquivo temporário como dado para check_output.
     data = config_file.read_text()
-    yield mocker.patch(
+    return mocker.patch(
         "ppycron.src.unix.subprocess.check_output",
         return_value=data.encode("utf-8"),
     )
@@ -29,7 +29,6 @@ def subprocess_check_output(mocker, config_file):
 @pytest.fixture
 def crontab(subprocess_run):
     from ppycron.src.unix import UnixInterface
-
     return UnixInterface()
 
 
@@ -37,31 +36,11 @@ def crontab(subprocess_run):
     "cron_line,interval,command",
     [
         ('*/15 0 * * * echo "hello"', "*/15 0 * * *", 'echo "hello"'),
-        (
-            "1 * * * 1,2 echo this-is-a-test",
-            "1 * * * 1,2",
-            "echo this-is-a-test",
-        ),
-        (
-            "*/2 * * * * echo for-this-test",
-            "*/2 * * * *",
-            "echo for-this-test",
-        ),
-        (
-            "1 2 * * * echo we-will-need-tests",
-            "1 2 * * *",
-            "echo we-will-need-tests",
-        ),
-        (
-            "1 3-4 * * * echo soon-this-test",
-            "1 3-4 * * *",
-            "echo soon-this-test",
-        ),
-        (
-            "*/15 0 * * * sh /path/to/file.sh",
-            "*/15 0 * * *",
-            "sh /path/to/file.sh",
-        ),
+        ("1 * * * 1,2 echo this-is-a-test", "1 * * * 1,2", "echo this-is-a-test"),
+        ("*/2 * * * * echo for-this-test", "*/2 * * * *", "echo for-this-test"),
+        ("1 2 * * * echo we-will-need-tests", "1 2 * * *", "echo we-will-need-tests"),
+        ("1 3-4 * * * echo soon-this-test", "1 3-4 * * *", "echo soon-this-test"),
+        ("*/15 0 * * * sh /path/to/file.sh", "*/15 0 * * *", "sh /path/to/file.sh"),
     ],
 )
 def test_add_cron(
@@ -79,58 +58,44 @@ def test_add_cron(
     assert isinstance(cron, Cron)
     assert cron.command == command
     assert cron.interval == interval
-    # Ensure that the crontab command was executed
+    # Verifica se o id foi gerado e é uma string não vazia
+    assert cron.id and isinstance(cron.id, str)
     subprocess_run.assert_called_with(["crontab", mocker.ANY], check=True)
 
 
 @pytest.mark.parametrize(
     "cron_line,interval,command",
     [
-        (
-            '*/15 0 * * * echo "hello"',
-            "*/15 0 * * *",
-            'echo "hello"',
-        ),
-        (
-            "3 * * * 3,5 echo this-is-a-test",
-            "3 * * * 3,5",
-            "echo this-is-a-test",
-        ),
-        (
-            "*/6 * * * * echo for-this-test",
-            "*/6 * * * *",
-            "echo for-this-test",
-        ),
-        (
-            "9 3 * * * echo we-will-need-tests",
-            "9 3 * * *",
-            "echo we-will-need-tests",
-        ),
-        (
-            "10 2-4 * * * echo soon-this-test",
-            "10 2-4 * * *",
-            "echo soon-this-test",
-        ),
-        (
-            "*/15 0 * * * sh /path/to/file.sh",
-            "*/15 0 * * *",
-            "sh /path/to/file.sh",
-        ),
+        ('*/15 0 * * * echo "hello"', "*/15 0 * * *", 'echo "hello"'),
+        ("3 * * * 3,5 echo this-is-a-test", "3 * * * 3,5", "echo this-is-a-test"),
+        ("*/6 * * * * echo for-this-test", "*/6 * * * *", "echo for-this-test"),
+        ("9 3 * * * echo we-will-need-tests", "9 3 * * *", "echo we-will-need-tests"),
+        ("10 2-4 * * * echo soon-this-test", "10 2-4 * * *", "echo soon-this-test"),
+        ("*/15 0 * * * sh /path/to/file.sh", "*/15 0 * * *", "sh /path/to/file.sh"),
     ],
 )
 def test_get_cron_jobs(
     crontab, config_file, cron_line, interval, command, subprocess_check_output
 ):
-    crontab.get_all()
+    # Ajusta o arquivo de configuração para conter uma linha com o identificador
+    fake_cron_line = f"{cron_line} # id: test-cron-id"
+    config_file.write_text(fake_cron_line + "\n")
+    # Atualiza o valor de retorno do mock para refletir o conteúdo atualizado do arquivo
+    subprocess_check_output.return_value = config_file.read_text().encode("utf-8")
+    crons = crontab.get_all()
+    # Verifica se pelo menos uma das entradas possui o id esperado
+    assert any(c.id == "test-cron-id" for c in crons)
     subprocess_check_output.assert_called_with(["crontab", "-l"])
 
 
 def test_edit_cron(
     crontab, config_file, subprocess_check_output, subprocess_run, mocker
 ):
+    # Adiciona um job, que terá seu id gerado automaticamente
     job = crontab.add(command='echo "hello"', interval="*/15 0 * * *")
+    # Realiza a edição utilizando o identificador único do job
     crontab.edit(
-        cron_command=job.command, command="echo edited-command", interval="*/15 0 * * *"
+        cron_id=job.id, command="echo edited-command", interval="*/15 0 * * *"
     )
 
     subprocess_check_output.assert_called_with(["crontab", "-l"])
@@ -140,11 +105,12 @@ def test_edit_cron(
 def test_delete_cron(
     crontab, config_file, subprocess_check_output, subprocess_run, mocker
 ):
-    crontab.add(
+    # Adiciona um job e utiliza seu id para realizar a deleção
+    job = crontab.add(
         command="echo job_to_be_deleted",
         interval="*/15 0 * * *",
     )
-    crontab.delete(cron_command="echo job_to_be_deleted")
+    crontab.delete(cron_id=job.id)
 
     subprocess_check_output.assert_called_with(["crontab", "-l"])
     subprocess_run.assert_called_with(["crontab", mocker.ANY], check=True)


### PR DESCRIPTION
- Modify the Cron dataclass to include a unique UUID (id) for each cron job.
- Update the __str__ method to append the unique id as a comment in the crontab entry.
- Adjust UnixInterface.get_all to extract and include the unique id when parsing cron lines.
- Refactor edit and delete methods to operate using the unique id instead of the command.
- Update tests and the usage section in the README to reflect the new behavior.